### PR TITLE
Match type of arguments to min() and max()

### DIFF
--- a/examples/ConsoleShell/ConsoleShell.ino
+++ b/examples/ConsoleShell/ConsoleShell.ino
@@ -140,7 +140,7 @@ void SetLedState()
 void SetBrightness() 
 {
   // clamp value intervalOn on 0 and PWMinterval
-  intervalOn  =  max(min(ledBrightness,PWMinterval),0);
+  intervalOn  =  max(min((unsigned long)ledBrightness,PWMinterval),0ul);
 }
 
 // Pulse Width Modulation to vary Led intensity

--- a/utility/HeaterSim.cpp
+++ b/utility/HeaterSim.cpp
@@ -70,7 +70,7 @@ void HeaterSim::CalcTemperature()
 {
 	float rate                  = LN2/_halfTimeCooling;	 
 	unsigned long currentTime   = millis();
-	if (currentTime >= _lastTime) _deltams = max(currentTime - _lastTime,1);
+	if (currentTime >= _lastTime) _deltams = max(currentTime - _lastTime,1ul);
 	_deltaTime                  = _deltams/ 1000.0f;
 	float deltaTemp             = _boilerTemp - _ambientTemp;
 	float deltaTempAfterCooling = deltaTemp*exp(-rate*_deltaTime);


### PR DESCRIPTION
max() and min() were changed from macros to templates in ESP8266 core for Arduino 2.4.0. This change causes calls to these functions with arguments of different types to cause a compilation error "error: no matching function for call to". This commit changes the arguments to these functions to the same type to fix compatibility with ESP8266.