### PR TITLE
Make license formatting match GitHub's reference text

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,8 +1,6 @@
-#  MIT License
---------------
-Copyright (c) 2013, 2014, 2015, 2016, 2017 
-	Thijs Elenbaas, Valeriy Kucherenko,
-	Dreamcat4, Neil Dudman, Thomas Ouellet Fredericks.
+MIT License
+
+Copyright (c) 2013, 2014, 2015, 2016, 2017 Thijs Elenbaas, Valeriy Kucherenko, Dreamcat4, Neil Dudman, Thomas Ouellet Fredericks.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
GitHub uses the licensee ruby gem to detect the license type of the repository. licensee uses the license texts from choosealicense.com so if the text of your license file differs from their license it will not be recognized. GitHub allows filtering searches by license type and also shows the license type on the homepage of your repository and when viewing the license page but these features are only available when the license is recognized.

This does NOT change the actual content of the license in any way.