### PR TITLE
Fixed upstream issue 49, '\0' to NULL

### DIFF
--- a/CmdMessenger.cpp
+++ b/CmdMessenger.cpp
@@ -497,7 +497,7 @@ char* CmdMessenger::readStringArg()
 		return current;
 	}
 	ArgOk = false;
-	return '\0';
+	return NULL;
 }
 
 /**


### PR DESCRIPTION
See https://github.com/thijse/Arduino-CmdMessenger/issues/49 .  There's some kinda difference between compilers that causes an error when you try to return '\0' for a *char.  I think it's unclear whether the author originally meant to return an empty string, or NULL - but I've left the behavior (I believe) the same, with NULL.